### PR TITLE
Add new transform: Tee class

### DIFF
--- a/src/transforms/tee.cpp
+++ b/src/transforms/tee.cpp
@@ -1,0 +1,58 @@
+#include "tee.h"
+
+Tee::Tee( uint16_t isTeeActive, float coefficient_tap, float offset_tap, void (*pFunc_tap)(float x), String config_path ) : 
+          NumericTransform(config_path), 
+          isTeeActive{isTeeActive}, coefficient_tap{coefficient_tap}, offset_tap{offset_tap}  {
+  className = "Tee";
+  load_configuration();
+  tee_to = pFunc_tap;
+}
+
+void Tee::set_input(float input, uint8_t inputChannel) {
+
+        output = input; //pass input value unchanged to next in chain
+         if( isTeeActive )
+        {   //route the data to external function, which can e.g. send it to GPIO, or log it, or...
+            (*tee_to)( (float)input * coefficient_tap + offset_tap); //apply y = mx + b linear equation to input
+        }
+        notify();  
+}
+
+JsonObject& Tee::get_configuration(JsonBuffer& buf) {
+  JsonObject& root = buf.createObject();
+  root["coefficient_tap"] = coefficient_tap;
+  root["offset_tap"] = offset_tap;
+  root["isTeeActive"] = isTeeActive;
+  debugI( "Tee get_configuration: coefficient_tap=%f offset_tap=%f isTeeActive=%d", 
+          coefficient_tap, offset_tap, isTeeActive );
+  return root;
+}
+
+static const char SCHEMA[] PROGMEM = R"###({
+    "type": "object",
+    "properties": {
+       "coefficient_tap": { "title": "Coefficient m in y=mx + b", "description": "converts Alternator signal (Hz) into Tachometer Signal (Hz)", "type": "number" },
+       "offset_tap": { "title": "Offset b in y=mx + b", "type": "number" },
+       "isTeeActive": { "title": "Tee Active", "description": "Whether value passing through is echoed to GPIO. 0 = no passthrough.", "type": "number" }
+    }
+  })###"; //some examples lack the ### - what are they for? Are they needed?
+
+String Tee::get_config_schema() {
+  return FPSTR(SCHEMA);
+}
+
+
+bool Tee::set_configuration(const JsonObject& config) {
+  String expected[] = {"isTeeActive", "coefficient_tap", "offset_tap" };
+  for (auto str : expected) {
+    if (!config.containsKey(str)) 
+    { debugI( "Tee set_configuration: couldn't find %s", str.c_str() );
+      return false;
+    }
+  }
+  isTeeActive = config["isTeeActive"];
+  coefficient_tap = config["coefficient_tap"];
+  offset_tap = config["offset_tap"];
+  debugI( "Tee set_configuration: coefficient_tap=%f offset_tap=%f isTeeActive=%d", coefficient_tap, offset_tap, isTeeActive );
+  return true;
+}

--- a/src/transforms/tee.h
+++ b/src/transforms/tee.h
@@ -1,0 +1,56 @@
+#ifndef tee_H
+#define tee_H
+
+#include "transforms/transform.h"
+
+/**
+ * from https://isocpp.org/wiki/faq/pointers-to-members#fnptr-vs-memfnptr-types
+ * Allows call to an external function (e.g. one defined in main.cpp), which then has job of manipulating 
+ * a copy of the data passing through the tee. Alternative would be to expose member fcn 
+ * to the Tee class, and pass in reference to instance in the connectTo() method of main.cpp.
+ * This latter approach seemed difficult.
+ */
+ typedef  void (*WrapperFcn)(float x);  
+
+/**
+ * Tee is a numeric passthrough transform that always passes the value unchanged. 
+ * It also optionally applies a linear transform of the form y = mx + b, and then passes the y value
+ *  to an external function: tee_to().  This external function can be used, for example, to output the
+ *  y value in the form of a frequency-modulated signal on a GPIO pin.
+ * 
+ * The Tee class is so called because it inserts a tee, or tap, into the string of value Producers/Consumers.
+ * How to use: 
+ *   #include tee.h in main.cpp.  
+ *   Define a class that manipulates the data however you want. For example, a WaveformGen class that outputs
+ *     a square wave on a GPIO of a frequency proportional to the data.
+ *   In main.cpp, declare a wrapper function that invokes your data output class:
+ *     WaveformGen* pTachOutputObj; // Wrapper function uses a global to remember the object:
+ *     void TeeOutput_wrapper( float new_freq )
+ *     {    //Changes the output frequency to new_freq using WaveformGen member set_freq()
+ *          pTachOutputObj->set_freq( (int)(new_freq) );
+ *          debugI( "f= %d", (int)(new_freq) );
+ *     }
+ *  Finally, in main.cpp where you setup your data Producer/Consumer chain:
+ *      pSensor_tach->connectTo(new Frequency( multiplier_tach, config_path_rpm_calibrate)) // connect the output of pSensor to the input of Frequency()
+ *          ->connectTo(new Tee( true, 1.0, 1.0, TeeOutput_wrapper, config_path_rpm_tee ))  // connect the output via a tee to waveform generator
+ *          ->connectTo(new SKOutputNumber( sk_path_rpm, config_path_rpm_skpath ));         // connect the output to SignalK Output as a number
+ * 
+ */
+class Tee : public NumericTransform {
+
+    public:
+        Tee(uint16_t isTeeActive, float coefficient_tap, float offset_Tap, void (*pFunc_tap)(float x), String config_path="");
+        virtual void set_input(float input, uint8_t inputChannel = 0) override;
+        virtual JsonObject& get_configuration(JsonBuffer& buf) override;
+        virtual bool set_configuration(const JsonObject& config) override;
+        virtual String get_config_schema() override;
+
+    private:
+        uint16_t isTeeActive;
+        float coefficient_tap;
+        float offset_tap;
+        WrapperFcn tee_to;
+};
+
+
+#endif


### PR DESCRIPTION
I've drafted a new transform, called **Tee**. Tee is a numeric passthrough transform that always passes the value unchanged. It also optionally applies a linear transform of the form y = mx + b, and then passes that y value to an external function.  This external function can be used, for example, to output y in the form of a frequency-modulated signal on a GPIO pin. The Tee class is so called because **it inserts a tee, or tap, into the chain of value Producers/Consumers**. It won't change the value passing through the chain, but allows one to use the value for some local purpose.

I wrote this because our boat has an analog tachometer that takes a square-wave input and displays a corresponding RPM. I wanted to use this tachometer in addition to publishing the engine speed on the SignalK network. So I connected an ESP32 input to the Alternator's AC output, converting the reading to frequency using the SensESP Tachometer example. Inserting the Tee producer/consumer into the signal chain, and pointing it to a function that outputs a square-wave signal whose frequency corresponds to the frequency value, allows the ESP32 to control the analog tachometer display in addition to sending the RPM value to SignalK subscribers.

Another possible use for a tap, other than mirroring a signal out on a GPIO pin, might include directing the values to a logging function - i.e. one that is local to the ESP32, not on the external SignalK network.

There may be easier ways of implementing this solution - I'm not making any claims about the elegance of my code as I am more of a hardware engineer than software. Hopefully some others will find it a useful addition to the library of SignalK functions.  I've tested it on the ESP32-WROVER-KIT, and on the ESP32-DEVKIT-C devices. Feel free to critique/improve/correct this submission. 